### PR TITLE
feat: Adiciona pontuação das histórias ao relatório da sprint

### DIFF
--- a/resources/js/modules/reports/components/SprintReportDialogContent.vue
+++ b/resources/js/modules/reports/components/SprintReportDialogContent.vue
@@ -244,6 +244,11 @@ export default {
 					sortable: false,
 				},
 				{
+					text: 'Pontuação',
+					value: 'estimated',
+					sortable: false,
+				},
+				{
 					text: 'Detalhes',
 					value: 'details',
 					sortable: false,


### PR DESCRIPTION
## Para testar ##

- Compile o front;
- Acesse a seção de Sprint e verifique se no modal "Fechar sprint" são exibidas as pontuações das histórias;
- Acesse a seção de Relatórios de Sprint e verifique se nos modais de "Resumo de Sprint" as pontuações são exibidas da mesma maneira;
- Deixe seu like e se inscreva no canal.