### PR TITLE
Hotfix/team velocity with less than 8 sprints

### DIFF
--- a/resources/js/modules/reports/views/SprintReport.vue
+++ b/resources/js/modules/reports/views/SprintReport.vue
@@ -197,7 +197,7 @@ export default {
 		},
 
 		getTeamVelocity() {
-			const numberOfSprintsToConsider = 8;
+			const numberOfSprintsToConsider = this.sprints.length <= 8 ? this.sprints.length : 8;
 			const sprintsToConsider = this.sprints.slice(0, numberOfSprintsToConsider);
 			const velocity = sprintsToConsider.reduce((acc, curr) => acc + this.getDeliveredPoints(curr), 0);
 


### PR DESCRIPTION
Corrige cálculo da velocidade dos times quando os times não possuírem mais que 8 relatórios de sprint