### PR TITLE
Adiciona verificação se lista existe ao criar card

### DIFF
--- a/app/Http/Requests/StoreCardRequest.php
+++ b/app/Http/Requests/StoreCardRequest.php
@@ -27,7 +27,7 @@ class StoreCardRequest extends FormRequest
 		return [
 			'title' => 'required|string',
 			'type' => "required|in:$types",
-			'board_list_id' => 'required|string',
+			'board_list_id' => 'required|string|exists:board_lists,_id',
 			'user_story_id' => 'nullable|string',
 			'members' => 'nullable|array',
 			'team_id' => 'nullable|string',


### PR DESCRIPTION
Para testar você pode configurar a API tal qual explicado [nesse link](https://github.com/Sysvale/board/blob/develop/API.md).

- Teste fazer a requisição com um id que não está na base de dados e verifique que a requisição retorna com erro.
- Verifique que ao enviar um id de uma lista que existe o card é criado