### PR TITLE
Cria rota de API para criar ou atualizar uma lista de cards

### DIFF
--- a/API.md
+++ b/API.md
@@ -127,41 +127,45 @@ para evitar redirecionamentos em caso de erros de validação ou autenticação.
 }
 ```
 
-#### /api/cards
-##### Request [PUT]
+#### /api/cards/batch
+##### Request [POST]
 ```json
 {
-  [
-    "title": "Card criado via api", // titulo do card
-	  "type":  "user-story", // tipo do card. para mais tipos ver: App/Constants/CardTypes
-		"board_list_id" : "645259f8ec05ef07130f31a8", // id da lista onde o card será criado
-		"user_story_id": "6458e1a8a90d9a6e0e697d02", // opcional, deve ser enviado quando o card criado é do tipo task
+	"batch_key" => "integration_metadata.granatum", // chave do id do elemento atrelado ao card, deve ser uma string
+  "cards" => [ // array com os cards
+		[
+			"title": "Card criado via api", // titulo do card
+			"type":  "user-story", // tipo do card. para mais tipos ver: App/Constants/CardTypes
+			"board_list_id" : "645259f8ec05ef07130f31a8", // id da lista onde o card será criado
+			"user_story_id": "6458e1a8a90d9a6e0e697d02", // opcional, deve ser enviado quando o card criado é do tipo task
 			"integration_metadata": [
-				"granatum": [ // nome da aplicação
-					"id": "1231y54kh3khiu1g23uh6" // id do elemento atrelado ao card
+				"granatum": [ // chaves seguindo a lógica da variável batch_key
+					"id": "1231y54kh3khiu1g23uh6" // id do elemento atrelado ao card, deve ser uma string
 				]
 			]
+		],
+	],
+}_
+```
+
+##### Response: [200 - OK]
+``` json
+{
+  "ids" => [ // lista dos ids dos cards enviados
+    "65aa64fa9c80a91a0c36a68a",
 	],
 }
 ```
 
-##### Response: Array dos Cards
+##### Response: [422 - UNPROCESSABLE] indica erros de validação
 ``` json
 {
-  [
-    "id": "65aa64fa9c80a91a0c36a68a",
-    "number": 1,
-    "created_at": "19/01/2024 12:03",
-    "board_list_id": "645259f8ec05ef07130f31a8",
-    "user_story_id": "6458e1a8a90d9a6e0e697d02",
-    "title": "Card criado via api",
-    "position": 0,
-    "first_default_board_list_id": null,
-    "integration_metadata": {
-      "granatum": {
-        "id": "1231y54kh3khiu1g23uh6",
-      }
-    },
-	],
+	"message": "The given data was invalid.",
+	"errors": {
+		// cada campo com erro tem uma chave em errors, com um array de erros de validação para o campo
+		"type": [
+			"The selected type is invalid."
+		]
+	}
 }
 ```

--- a/API.md
+++ b/API.md
@@ -131,7 +131,7 @@ para evitar redirecionamentos em caso de erros de validação ou autenticação.
 ##### Request [POST]
 ```json
 {
-	"update_attribute" => "integration_metadata.granatum.id", // chave do id do elemento atrelado ao card, deve ser uma string
+	"update_attribute" => "integration_metadata.granatum.id", // atributo que será utilizado como critério para verificar a existência do elemento (caso exista, será atualizado. Caso não, será criado)
   "cards" => [ // array com os cards
 		[
 			"title": "Card criado via api", // título do card

--- a/API.md
+++ b/API.md
@@ -134,7 +134,7 @@ para evitar redirecionamentos em caso de erros de validação ou autenticação.
 	"batch_key" => "integration_metadata.granatum", // chave do id do elemento atrelado ao card, deve ser uma string
   "cards" => [ // array com os cards
 		[
-			"title": "Card criado via api", // titulo do card
+			"title": "Card criado via api", // título do card
 			"type":  "user-story", // tipo do card. para mais tipos ver: App/Constants/CardTypes
 			"board_list_id" : "645259f8ec05ef07130f31a8", // id da lista onde o card será criado
 			"user_story_id": "6458e1a8a90d9a6e0e697d02", // opcional, deve ser enviado quando o card criado é do tipo task

--- a/API.md
+++ b/API.md
@@ -131,7 +131,7 @@ para evitar redirecionamentos em caso de erros de validação ou autenticação.
 ##### Request [POST]
 ```json
 {
-	"batch_key" => "integration_metadata.granatum", // chave do id do elemento atrelado ao card, deve ser uma string
+	"update_attribute" => "integration_metadata.granatum.id", // chave do id do elemento atrelado ao card, deve ser uma string
   "cards" => [ // array com os cards
 		[
 			"title": "Card criado via api", // título do card
@@ -139,7 +139,7 @@ para evitar redirecionamentos em caso de erros de validação ou autenticação.
 			"board_list_id" : "645259f8ec05ef07130f31a8", // id da lista onde o card será criado
 			"user_story_id": "6458e1a8a90d9a6e0e697d02", // opcional, deve ser enviado quando o card criado é do tipo task
 			"integration_metadata": [
-				"granatum": [ // chaves seguindo a lógica da variável batch_key
+				"granatum": [ // chaves seguindo a lógica da variável update_attribute
 					"id": "1231y54kh3khiu1g23uh6" // id do elemento atrelado ao card, deve ser uma string
 				]
 			]

--- a/API.md
+++ b/API.md
@@ -135,7 +135,7 @@ para evitar redirecionamentos em caso de erros de validação ou autenticação.
   "cards" => [ // array com os cards
 		[
 			"title": "Card criado via api", // título do card
-			"type":  "user-story", // tipo do card. para mais tipos ver: App/Constants/CardTypes
+			"type":  "task", // tipo do card. para mais tipos ver: App/Constants/CardTypes
 			"board_list_id" : "645259f8ec05ef07130f31a8", // id da lista onde o card será criado
 			"user_story_id": "6458e1a8a90d9a6e0e697d02", // opcional, deve ser enviado quando o card criado é do tipo task
 			"integration_metadata": [

--- a/API.md
+++ b/API.md
@@ -126,3 +126,42 @@ para evitar redirecionamentos em caso de erros de validação ou autenticação.
 	}
 }
 ```
+
+#### /api/cards
+##### Request [PUT]
+```json
+{
+  [
+    "title": "Card criado via api", // titulo do card
+	  "type":  "user-story", // tipo do card. para mais tipos ver: App/Constants/CardTypes
+		"board_list_id" : "645259f8ec05ef07130f31a8", // id da lista onde o card será criado
+		"user_story_id": "6458e1a8a90d9a6e0e697d02", // opcional, deve ser enviado quando o card criado é do tipo task
+			"integration_metadata": [
+				"granatum": [ // nome da aplicação
+					"id": "1231y54kh3khiu1g23uh6" // id do elemento atrelado ao card
+				]
+			]
+	],
+}
+```
+
+##### Response: Array dos Cards
+``` json
+{
+  [
+    "id": "65aa64fa9c80a91a0c36a68a",
+    "number": 1,
+    "created_at": "19/01/2024 12:03",
+    "board_list_id": "645259f8ec05ef07130f31a8",
+    "user_story_id": "6458e1a8a90d9a6e0e697d02",
+    "title": "Card criado via api",
+    "position": 0,
+    "first_default_board_list_id": null,
+    "integration_metadata": {
+      "granatum": {
+        "id": "1231y54kh3khiu1g23uh6",
+      }
+    },
+	],
+}
+```

--- a/app/Http/Controllers/CardController.php
+++ b/app/Http/Controllers/CardController.php
@@ -197,22 +197,22 @@ class CardController extends Controller
 	{
 		$request->validate([
 			'cards' => 'nullable|array',
-			'batch_key' => 'required|string',
+			'update_attribute' => 'required|string',
 		]);
 
 		$card_keys = [];
-		$batch_key = $request->batch_key;
+		$update_attribute = $request->update_attribute;
 
 		foreach($request->cards as $card) {
 			$card = Card::updateOrCreate([
-				"$batch_key.id" => data_get($card, "$batch_key.id"),
+				$update_attribute => data_get($card, $update_attribute),
 			], $card);
 
 			if ($card['team_key']) {
 				$card->first_default_board_list_id = $this->getFirstDefaultBoardListId($card['team_key']);
 			}
 
-			array_push($card_keys, data_get($card, "$batch_key.id"));
+			array_push($card_keys, data_get($card, $update_attribute));
 		};
 
 		return ['ids' => $card_keys];

--- a/app/Http/Controllers/CardController.php
+++ b/app/Http/Controllers/CardController.php
@@ -180,6 +180,7 @@ class CardController extends Controller
 			'description' => $request->description,
 			'status' => $request->status,
 			'milestone_id' => $request->milestone_id,
+			'integration_metadata' => $request->integration_metadata,
 		];
 
 		$cleaned_data = array_filter($params, function ($value) {
@@ -190,6 +191,26 @@ class CardController extends Controller
 		$card->save();
 
 		return new CardResource($card);
+	}
+
+	public function updateOrCreate(Request $request)
+	{
+		$total = [];
+		foreach($request->cards as $card) {
+			$key = key($card['integration_metadata']);
+			$card = Card::updateOrCreate([
+				"integration_metadata.$key.id" => $card['integration_metadata'][$key]['id']
+			], $card);
+
+			if ($card['team_key']) {
+				$card->first_default_board_list_id = $this->getFirstDefaultBoardListId($card['team_key']);
+			}
+
+			array_push($total, $card);
+		};
+
+
+		return $total;
 	}
 
 	public function updateCardsPositions(Request $request)

--- a/app/Http/Controllers/CardController.php
+++ b/app/Http/Controllers/CardController.php
@@ -206,9 +206,8 @@ class CardController extends Controller
 				$card->first_default_board_list_id = $this->getFirstDefaultBoardListId($card['team_key']);
 			}
 
-			array_push($total, $card);
+			array_push($total, new CardResource($card));
 		};
-
 
 		return $total;
 	}

--- a/app/Http/Resources/CardResource.php
+++ b/app/Http/Resources/CardResource.php
@@ -45,6 +45,7 @@ class CardResource extends JsonResource
 			'artifacts' => $this->when(isset($this->artifacts), $this->artifacts),
 			'first_default_board_list_id' => $this->first_default_board_list_id,
 			'milestone_id' => $this->when(isset($this->milestone_id), $this->milestone_id),
+			'integration_metadata' => $this->when(isset($this->integration_metadata), $this->integration_metadata),
 		];
 	}
 }

--- a/app/Http/Resources/CardResource.php
+++ b/app/Http/Resources/CardResource.php
@@ -45,7 +45,6 @@ class CardResource extends JsonResource
 			'artifacts' => $this->when(isset($this->artifacts), $this->artifacts),
 			'first_default_board_list_id' => $this->first_default_board_list_id,
 			'milestone_id' => $this->when(isset($this->milestone_id), $this->milestone_id),
-			'integration_metadata' => $this->when(isset($this->integration_metadata), $this->integration_metadata),
 		];
 	}
 }

--- a/app/Models/Card.php
+++ b/app/Models/Card.php
@@ -37,6 +37,7 @@ class Card extends Model
 		'estimated',
 		'status',
 		'milestone_id',
+		'integration_metadata',
 	];
 
 	protected $appends = ['id', 'is_user_story', 'is_not_prioritized', 'is_task'];

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,3 +22,7 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 Route::post('cards', [CardController::class, 'store'])
 	->middleware('client')
 	->name('api.cards.store');
+
+Route::put('cards/update-or-create', [CardController::class, 'updateOrCreate'])
+	->middleware('client')
+	->name('api.cards.updateOrCreate');

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,6 +23,6 @@ Route::post('cards', [CardController::class, 'store'])
 	->middleware('client')
 	->name('api.cards.store');
 
-Route::put('cards/update-or-create', [CardController::class, 'updateOrCreate'])
+Route::post('cards/batch', [CardController::class, 'handleBatch'])
 	->middleware('client')
-	->name('api.cards.updateOrCreate');
+	->name('api.cards.batch');

--- a/tests/Feature/App/Http/Controllers/CardControllerTest.php
+++ b/tests/Feature/App/Http/Controllers/CardControllerTest.php
@@ -87,7 +87,7 @@ class CardControllerTest extends TestCase
 		$task_card->title = 'Change Title';
 
 		$data = [
-				"batch_key" => "integration_metadata.granatum",
+				"update_attribute" => "integration_metadata.granatum.id",
 				"cards" => [
 					[
 						"title" => $task_card->title,
@@ -145,7 +145,7 @@ class CardControllerTest extends TestCase
 		$user_story_card = factory(Card::class)->create();
 
 		$data = [
-				"batch_key" => ["integration_metadata.granatum"],
+				"update_attribute" => ["integration_metadata.granatum.id"],
 				"cards" => [
 					[
 						"title" => "Card criado via api",


### PR DESCRIPTION
- Adiciona rota de API `/cards/batch` para atualizar uma lista de cards, no formato:
```
{
    "batch_key" => "integration_metadata.granatum", // chave do id do elemento atrelado ao card, deve ser uma string
    "cards" => [ // array com os cards
        [
	    "title": "Card criado via api", // título do card
            "type":  "user-story", // tipo do card. para mais tipos ver: App/Constants/CardTypes
	    "board_list_id" : "645259f8ec05ef07130f31a8", // id da lista onde o card será criado
	    "user_story_id": "6458e1a8a90d9a6e0e697d02", // opcional, deve ser enviado quando o card criado é do tipo task
	    "integration_metadata": [
		"granatum": [ // chaves seguindo a lógica da variável batch_key
		    "id": "1231y54kh3khiu1g23uh6" // id do elemento atrelado ao card, deve ser uma string
	        ]
	    ]
        ],
    ],
}
```

- Atualiza API.md com a nova rota
 